### PR TITLE
Update InGameInfo_zh_CN.xml

### DIFF
--- a/config/InGameInfoXML/InGameInfo_zh_CN.xml
+++ b/config/InGameInfoXML/InGameInfo_zh_CN.xml
@@ -814,12 +814,12 @@
             <operation>
                 <str>GT</str>
                 <var>bmmaxlp</var>
-                    <num>29000000</num>
-                    <num>9000000</num>
-                    <num>900000</num>
-                    <num>149000</num>
-                    <num>24000</num>
-                    <num>4900</num>
+                    <num>29999999</num>
+                    <num>9999999</num>
+                    <num>999999</num>
+                    <num>149999</num>
+                    <num>24999</num>
+                    <num>4999</num>
                     <num>-1</num>
                         <str>6</str>
                         <str>5</str>

--- a/config/InGameInfoXML/InGameInfo_zh_CN.xml
+++ b/config/InGameInfoXML/InGameInfo_zh_CN.xml
@@ -19,18 +19,17 @@
                 <str/>
             </op>
             <var>fps</var>
-            <str>     </str>
             <icon>
                 <str>minecraft:daylight_detector</str>
             </icon>
-            <str> $f现实时间： $r</str>
+            <str>              $f现实时间： $r</str>
             <str>$6{rltime24} $r</str>
         </line>
         <line>
             <icon>
                 <str>minecraft:clock</str>
             </icon>
-            <str> MC日期： 第{darkaqua} </str>
+            <str> MC日期  ： 第{darkaqua} </str>
             <add>
                 <round>
                     <div>
@@ -63,7 +62,7 @@
             <icon>
                 <str>HardcoreEnderExpansion:temple_end_portal</str>
             </icon>
-            <str> 世界：{gold} </str>
+            <str> 世界      ：{gold} </str>
                 <op>
                     <str>eq</str>
                     <var>dimensionid</var>
@@ -213,6 +212,13 @@
                     <str>$6花园/虚空世界 $e({dimensionid})</str>
                 </if>
             <str> {white}已加载区块数： {gold}{loadedchunks} </str>
+        </line>
+        <line>
+            <icon>
+                <str>minecraft:skull</str>
+                <num>4</num>
+            </icon>
+            <str> 实体      ： {gold}{entitiesrendered}{white} 已显现 / {gold}{entitiestotal}{white} 已加载  </str>
         </line>
         <line>
             <icon>
@@ -735,13 +741,6 @@
         </line>
         <line>
             <icon>
-                <str>minecraft:skull</str>
-                <num>4</num>
-            </icon>
-            <str> 实体： {gold}{entitiesrendered}{white} 已显现 / {gold}{entitiestotal}{white} 已加载  </str>
-        </line>
-        <line>
-            <icon>
                 <str>minecraft:compass</str>
                 <num>0</num>
             </icon>
@@ -800,391 +799,39 @@
                 <str>Thaumcraft:ItemResource</str>
                 <num>4</num>
             </icon>
-			<str> 神秘时代： </str>
-            <str> 永久扭曲： $4{tcwarpperm}$f</str>
-            <str> 一般扭曲： $4{tcwarpsticky}$f</str>
-            <str> 临时扭曲： $4{tcwarptemp}$f </str>
+			<str> 神秘时代：</str>
+            <str> 永久扭曲：$4{tcwarpperm}$f   </str>
+            <str> 一般扭曲：$4{tcwarpsticky}$f   </str>
+            <str> 临时扭曲：$4{tcwarptemp}$f </str>
         </line>
         <line>
             <icon>
                 <str>BloodArsenal:heart</str>
                 <num>4</num>
             </icon>
-            <str> 血魔法： </str>
-            <str> 当前LP： $6</str>
+            <str> 血魔法   ：</str>
+            <str> $6宝珠等级：$4</str>
+            <operation>
+                <str>GT</str>
+                <var>bmmaxlp</var>
+                    <num>29000000</num>
+                    <num>9000000</num>
+                    <num>900000</num>
+                    <num>149000</num>
+                    <num>24000</num>
+                    <num>4900</num>
+                    <num>-1</num>
+                        <str>6</str>
+                        <str>5</str>
+                        <str>4</str>
+                        <str>3</str>
+                        <str>2</str>
+                        <str>1</str>
+                        <str>0</str>
+            </operation>
+            <str>$f </str>
 
-            <if>
-                <greater>
-                    <round>
-                        <sub>
-                            <var>bmlp</var>
-                            <div>
-                                <num>1000000000</num><num>2</num>
-                            </div>
-                        </sub>
-                        <num>-9</num>
-                    </round>
-                    <num>0</num>
-                </greater>
-                <concat>
-                    <round>
-                        <div>
-                            <round>
-                                <sub>
-                                    <var>bmlp</var>
-                                    <div>
-                                        <num>1000000000</num><num>2</num>
-                                    </div>
-                                </sub>
-                                <num>-9</num>
-                            </round>
-                            <num>1000000000</num>
-                        </div>
-                        <num>0</num>
-                    </round>
-                    <str>,</str>
-                </concat>
-            </if>
-            <if>
-                <greater>
-                    <round>
-                        <sub>
-                            <var>bmlp</var>
-                            <div>
-                                <num>1000000000</num><num>2</num>
-                            </div>
-                        </sub>
-                        <num>-9</num>
-                    </round>
-                    <num>0</num>
-                </greater>
-                <if>
-                    <equal>
-                        <div>
-                            <round>
-                                <sub>
-                                    <div>
-                                        <sub>
-                                                <round>
-                                                    <sub>
-                                                        <var>bmlp</var>
-                                                        <div>
-                                                            <num>1000000</num><num>2</num>
-                                                        </div>
-                                                    </sub>
-                                                    <num>-6</num>
-                                                </round>
-                                                <round>
-                                                    <sub>
-                                                        <var>bmlp</var>
-                                                        <div>
-                                                            <num>1000000000</num><num>2</num>
-                                                        </div>
-                                                    </sub>
-                                                    <num>-9</num>
-                                                </round>
-                                        </sub>
-                                        <num>1000000</num>
-                                    </div>
-                                    <num>50</num>
-                                </sub>
-                                <num>-2</num>
-                            </round>
-                            <num>100</num>
-                        </div>
-                        <num>0</num>
-                    </equal>
-                    <concat>
-                        <str>0</str>
-                        <if>
-                            <equal>
-                                <div>
-                                    <round>
-                                        <sub>
-                                            <div>
-                                                <sub>
-                                                        <round>
-                                                            <sub>
-                                                                <var>bmlp</var>
-                                                                <div>
-                                                                    <num>1000000</num><num>2</num>
-                                                                </div>
-                                                            </sub>
-                                                            <num>-6</num>
-                                                        </round>
-                                                        <sub>
-                                                            <var>bmlp</var>
-                                                            <modi><var>bmlp</var><num>1000000000</num></modi>
-                                                        </sub>
-                                                </sub>
-                                                <num>1000000</num>
-                                            </div>
-                                            <num>5</num>
-                                        </sub>
-                                        <num>-1</num>
-                                    </round>
-                                    <num>10</num>
-                                </div>
-                                <num>0</num>
-                            </equal>
-                            <str>0</str>
-                        </if>
-                    </concat>
-                </if>
-            </if>
-            <concat>
-                <round>
-                    <div>
-                        <sub>
-                                <round>
-                                    <sub>
-                                        <var>bmlp</var>
-                                        <div>
-                                            <num>1000000</num><num>2</num>
-                                        </div>
-                                    </sub>
-                                    <num>-6</num>
-                                </round>
-                                <round>
-                                    <sub>
-                                        <var>bmlp</var>
-                                        <div>
-                                            <num>1000000000</num><num>2</num>
-                                        </div>
-                                    </sub>
-                                    <num>-9</num>
-                                </round>
-                        </sub>
-                        <num>1000000</num>
-                    </div>
-                    <num>0</num>
-                </round>
-                <str>,</str>
-            </concat>
-            <if>
-                <greater>
-                    <round>
-                        <sub>
-                            <var>bmlp</var>
-                            <div>
-                                <num>1000000</num><num>2</num>
-                            </div>
-                        </sub>
-                        <num>-6</num>
-                    </round>
-                    <num>0</num>
-                </greater>
-                <if>
-                    <equal>
-                        <div>
-                            <round>
-                                <sub>
-                                    <div>
-                                        <sub>
-                                                <round>
-                                                    <sub>
-                                                        <var>bmlp</var>
-                                                        <div>
-                                                            <num>1000</num><num>2</num>
-                                                        </div>
-                                                    </sub>
-                                                    <num>-3</num>
-                                                </round>
-                                                <round>
-                                                    <sub>
-                                                        <var>bmlp</var>
-                                                        <div>
-                                                            <num>1000000</num><num>2</num>
-                                                        </div>
-                                                    </sub>
-                                                    <num>-6</num>
-                                                </round>
-                                        </sub>
-                                        <num>1000</num>
-                                    </div>
-                                    <num>50</num>
-                                </sub>
-                                <num>-2</num>
-                            </round>
-                            <num>100</num>
-                        </div>
-                        <num>0</num>
-                    </equal>
-                    <concat>
-                        <str>0</str>
-                        <if>
-                            <equal>
-                                <div>
-                                    <round>
-                                        <sub>
-                                            <div>
-                                                <sub>
-                                                        <round>
-                                                            <sub>
-                                                                <var>bmlp</var>
-                                                                <div>
-                                                                    <num>1000</num><num>2</num>
-                                                                </div>
-                                                            </sub>
-                                                            <num>-3</num>
-                                                        </round>
-                                                        <sub>
-                                                            <var>bmlp</var>
-                                                            <modi><var>bmlp</var><num>1000000</num></modi>
-                                                        </sub>
-                                                </sub>
-                                                <num>1000</num>
-                                            </div>
-                                            <num>5</num>
-                                        </sub>
-                                        <num>-1</num>
-                                    </round>
-                                    <num>10</num>
-                                </div>
-                                <num>0</num>
-                            </equal>
-                            <str>0</str>
-                        </if>
-                    </concat>
-                </if>
-            </if>
-            <concat>
-                <round>
-                    <div>
-                        <sub>
-                                <round>
-                                    <sub>
-                                        <var>bmlp</var>
-                                        <div>
-                                            <num>1000</num><num>2</num>
-                                        </div>
-                                    </sub>
-                                    <num>-3</num>
-                                </round>
-                                <round>
-                                    <sub>
-                                        <var>bmlp</var>
-                                        <div>
-                                            <num>1000000</num><num>2</num>
-                                        </div>
-                                    </sub>
-                                    <num>-6</num>
-                                </round>
-                        </sub>
-                        <num>1000</num>
-                    </div>
-                    <num>0</num>
-                </round>
-                <str>,</str>
-            </concat>
-            <if>
-                <greater>
-                    <round>
-                        <sub>
-                            <var>bmlp</var>
-                            <div>
-                                <num>1000</num><num>2</num>
-                            </div>
-                        </sub>
-                        <num>-3</num>
-                    </round>
-                    <num>0</num>
-                </greater>
-                <if>
-                    <equal>
-                        <div>
-                            <round>
-                                <sub>
-                                    <div>
-                                        <sub>
-                                                <var>bmlp</var>
-                                                <round>
-                                                    <sub>
-                                                        <var>bmlp</var>
-                                                        <div>
-                                                            <num>1000</num><num>2</num>
-                                                        </div>
-                                                    </sub>
-                                                    <num>-3</num>
-                                                </round>
-                                        </sub>
-                                        <num>1</num>
-                                    </div>
-                                    <num>50</num>
-                                </sub>
-                                <num>-2</num>
-                            </round>
-                            <num>100</num>
-                        </div>
-                        <num>0</num>
-                    </equal>
-                    <concat>
-                        <str>0</str>
-                        <if>
-                            <equal>
-                                <div>
-                                    <round>
-                                        <sub>
-                                            <div>
-                                                <sub>
-                                                        <var>bmlp</var>
-                                                        <round>
-                                                            <sub>
-                                                                <var>bmlp</var>
-                                                                <div>
-                                                                    <num>1000</num><num>2</num>
-                                                                </div>
-                                                            </sub>
-                                                            <num>-3</num>
-                                                        </round>
-                                                </sub>
-                                                <num>1</num>
-                                            </div>
-                                            <num>5</num>
-                                        </sub>
-                                        <num>-1</num>
-                                    </round>
-                                    <num>10</num>
-                                </div>
-                                <num>0</num>
-                            </equal>
-                            <str>0</str>
-                        </if>
-                    </concat>
-                </if>
-            </if>
-            <concat>
-                <round>
-                    <div>
-                        <sub>
-                                <round>
-                                    <sub>
-                                        <var>bmlp</var>
-                                        <div>
-                                            <num>1</num><num>2</num>
-                                        </div>
-                                    </sub>
-                                    <num>0</num>
-                                </round>
-                                <round>
-                                    <sub>
-                                        <var>bmlp</var>
-                                        <div>
-                                            <num>1000</num><num>2</num>
-                                        </div>
-                                    </sub>
-                                    <num>-3</num>
-                                </round>
-                        </sub>
-                        <num>1</num>
-                    </div>
-                    <num>0</num>
-                </round>
-                <str></str>
-            </concat>
-            <str>$f</str>
-
-            <str>最大LP： $6</str>
+            <str>$6- 最大LP：$4</str>            
             <if>
                 <greater>
                     <round>
@@ -1304,35 +951,50 @@
                     </concat>
                 </if>
             </if>
-            <concat>
-                <round>
-                    <div>
+            <if>
+                <greater>
+                    <round>
                         <sub>
-                                <round>
-                                    <sub>
-                                        <var>bmmaxlp</var>
-                                        <div>
-                                            <num>1000000</num><num>2</num>
-                                        </div>
-                                    </sub>
-                                    <num>-6</num>
-                                </round>
-                                <round>
-                                    <sub>
-                                        <var>bmmaxlp</var>
-                                        <div>
-                                            <num>1000000000</num><num>2</num>
-                                        </div>
-                                    </sub>
-                                    <num>-9</num>
-                                </round>
+                            <var>bmmaxlp</var>
+                            <div>
+                                <num>1000000</num><num>2</num>
+                            </div>
                         </sub>
-                        <num>1000000</num>
-                    </div>
+                        <num>-6</num>
+                    </round>
                     <num>0</num>
-                </round>
-                <str>,</str>
-            </concat>
+                </greater>
+                <concat>
+                    <round>
+                        <div>
+                            <sub>
+                                    <round>
+                                        <sub>
+                                            <var>bmmaxlp</var>
+                                            <div>
+                                                <num>1000000</num>
+                                                <num>2</num>
+                                            </div>
+                                        </sub>
+                                        <num>-6</num>
+                                    </round>
+                                    <round>
+                                        <sub>
+                                            <var>bmmaxlp</var>
+                                            <div>
+                                                <num>1000000000</num><num>2</num>
+                                            </div>
+                                        </sub>
+                                        <num>-9</num>
+                                    </round>
+                            </sub>
+                            <num>1000000</num>
+                        </div>
+                        <num>0</num>
+                    </round>
+                    <str>,</str>
+                </concat>
+            </if>
             <if>
                 <greater>
                     <round>
@@ -1420,35 +1082,49 @@
                     </concat>
                 </if>
             </if>
-            <concat>
-                <round>
-                    <div>
+            <if>
+                <greater>
+                    <round>
                         <sub>
-                                <round>
-                                    <sub>
-                                        <var>bmmaxlp</var>
-                                        <div>
-                                            <num>1000</num><num>2</num>
-                                        </div>
-                                    </sub>
-                                    <num>-3</num>
-                                </round>
-                                <round>
-                                    <sub>
-                                        <var>bmmaxlp</var>
-                                        <div>
-                                            <num>1000000</num><num>2</num>
-                                        </div>
-                                    </sub>
-                                    <num>-6</num>
-                                </round>
+                            <var>bmmaxlp</var>
+                            <div>
+                                <num>1000</num><num>2</num>
+                            </div>
                         </sub>
-                        <num>1000</num>
-                    </div>
+                        <num>-3</num>
+                    </round>
                     <num>0</num>
-                </round>
-                <str>,</str>
-            </concat>
+                </greater>
+                <concat>
+                    <round>
+                        <div>
+                            <sub>
+                                    <round>
+                                        <sub>
+                                            <var>bmmaxlp</var>
+                                            <div>
+                                                <num>1000</num><num>2</num>
+                                            </div>
+                                        </sub>
+                                        <num>-3</num>
+                                    </round>
+                                    <round>
+                                        <sub>
+                                            <var>bmmaxlp</var>
+                                            <div>
+                                                <num>1000000</num><num>2</num>
+                                            </div>
+                                        </sub>
+                                        <num>-6</num>
+                                    </round>
+                            </sub>
+                            <num>1000</num>
+                        </div>
+                        <num>0</num>
+                    </round>
+                    <str>,</str>
+                </concat>
+            </if>
             <if>
                 <greater>
                     <round>
@@ -1554,9 +1230,410 @@
                 </round>
                 <str></str>
             </concat>
-            <str>$f</str>
             <str>$f </str>
+
+            <str> 当前LP：$4</str>
+            <if>
+                <greater>
+                    <round>
+                        <sub>
+                            <var>bmlp</var>
+                            <div>
+                                <num>1000000000</num><num>2</num>
+                            </div>
+                        </sub>
+                        <num>-9</num>
+                    </round>
+                    <num>0</num>
+                </greater>
+                <concat>
+                    <round>
+                        <div>
+                            <round>
+                                <sub>
+                                    <var>bmlp</var>
+                                    <div>
+                                        <num>1000000000</num><num>2</num>
+                                    </div>
+                                </sub>
+                                <num>-9</num>
+                            </round>
+                            <num>1000000000</num>
+                        </div>
+                        <num>0</num>
+                    </round>
+                    <str>,</str>
+                </concat>
+            </if>
+            <if>
+                <greater>
+                    <round>
+                        <sub>
+                            <var>bmlp</var>
+                            <div>
+                                <num>1000000000</num><num>2</num>
+                            </div>
+                        </sub>
+                        <num>-9</num>
+                    </round>
+                    <num>0</num>
+                </greater>
+                <if>
+                    <equal>
+                        <div>
+                            <round>
+                                <sub>
+                                    <div>
+                                        <sub>
+                                                <round>
+                                                    <sub>
+                                                        <var>bmlp</var>
+                                                        <div>
+                                                            <num>1000000</num><num>2</num>
+                                                        </div>
+                                                    </sub>
+                                                    <num>-6</num>
+                                                </round>
+                                                <round>
+                                                    <sub>
+                                                        <var>bmlp</var>
+                                                        <div>
+                                                            <num>1000000000</num><num>2</num>
+                                                        </div>
+                                                    </sub>
+                                                    <num>-9</num>
+                                                </round>
+                                        </sub>
+                                        <num>1000000</num>
+                                    </div>
+                                    <num>50</num>
+                                </sub>
+                                <num>-2</num>
+                            </round>
+                            <num>100</num>
+                        </div>
+                        <num>0</num>
+                    </equal>
+                    <concat>
+                        <str>0</str>
+                        <if>
+                            <equal>
+                                <div>
+                                    <round>
+                                        <sub>
+                                            <div>
+                                                <sub>
+                                                        <round>
+                                                            <sub>
+                                                                <var>bmlp</var>
+                                                                <div>
+                                                                    <num>1000000</num><num>2</num>
+                                                                </div>
+                                                            </sub>
+                                                            <num>-6</num>
+                                                        </round>
+                                                        <sub>
+                                                            <var>bmlp</var>
+                                                            <modi><var>bmlp</var><num>1000000000</num></modi>
+                                                        </sub>
+                                                </sub>
+                                                <num>1000000</num>
+                                            </div>
+                                            <num>5</num>
+                                        </sub>
+                                        <num>-1</num>
+                                    </round>
+                                    <num>10</num>
+                                </div>
+                                <num>0</num>
+                            </equal>
+                            <str>0</str>
+                        </if>
+                    </concat>
+                </if>
+            </if>
+            <if>
+                <greater>
+                    <round>
+                        <sub>
+                            <var>bmlp</var>
+                            <div>
+                                <num>1000000</num><num>2</num>
+                            </div>
+                        </sub>
+                        <num>-6</num>
+                    </round>
+                    <num>0</num>
+                </greater>
+                <concat>
+                    <round>
+                        <div>
+                            <sub>
+                                    <round>
+                                        <sub>
+                                            <var>bmlp</var>
+                                            <div>
+                                                <num>1000000</num>
+                                                <num>2</num>
+                                            </div>
+                                        </sub>
+                                        <num>-6</num>
+                                    </round>
+                                    <round>
+                                        <sub>
+                                            <var>bmlp</var>
+                                            <div>
+                                                <num>1000000000</num><num>2</num>
+                                            </div>
+                                        </sub>
+                                        <num>-9</num>
+                                    </round>
+                            </sub>
+                            <num>1000000</num>
+                        </div>
+                        <num>0</num>
+                    </round>
+                    <str>,</str>
+                </concat>
+            </if>
+            <if>
+                <greater>
+                    <round>
+                        <sub>
+                            <var>bmlp</var>
+                            <div>
+                                <num>1000000</num><num>2</num>
+                            </div>
+                        </sub>
+                        <num>-6</num>
+                    </round>
+                    <num>0</num>
+                </greater>
+                <if>
+                    <equal>
+                        <div>
+                            <round>
+                                <sub>
+                                    <div>
+                                        <sub>
+                                                <round>
+                                                    <sub>
+                                                        <var>bmlp</var>
+                                                        <div>
+                                                            <num>1000</num><num>2</num>
+                                                        </div>
+                                                    </sub>
+                                                    <num>-3</num>
+                                                </round>
+                                                <round>
+                                                    <sub>
+                                                        <var>bmlp</var>
+                                                        <div>
+                                                            <num>1000000</num><num>2</num>
+                                                        </div>
+                                                    </sub>
+                                                    <num>-6</num>
+                                                </round>
+                                        </sub>
+                                        <num>1000</num>
+                                    </div>
+                                    <num>50</num>
+                                </sub>
+                                <num>-2</num>
+                            </round>
+                            <num>100</num>
+                        </div>
+                        <num>0</num>
+                    </equal>
+                    <concat>
+                        <str>0</str>
+                        <if>
+                            <equal>
+                                <div>
+                                    <round>
+                                        <sub>
+                                            <div>
+                                                <sub>
+                                                        <round>
+                                                            <sub>
+                                                                <var>bmlp</var>
+                                                                <div>
+                                                                    <num>1000</num><num>2</num>
+                                                                </div>
+                                                            </sub>
+                                                            <num>-3</num>
+                                                        </round>
+                                                        <sub>
+                                                            <var>bmlp</var>
+                                                            <modi><var>bmlp</var><num>1000000</num></modi>
+                                                        </sub>
+                                                </sub>
+                                                <num>1000</num>
+                                            </div>
+                                            <num>5</num>
+                                        </sub>
+                                        <num>-1</num>
+                                    </round>
+                                    <num>10</num>
+                                </div>
+                                <num>0</num>
+                            </equal>
+                            <str>0</str>
+                        </if>
+                    </concat>
+                </if>
+            </if>
+            <if>
+                <greater>
+                    <round>
+                        <sub>
+                            <var>bmlp</var>
+                            <div>
+                                <num>1000</num><num>2</num>
+                            </div>
+                        </sub>
+                        <num>-3</num>
+                    </round>
+                    <num>0</num>
+                </greater>
+                <concat>
+                    <round>
+                        <div>
+                            <sub>
+                                    <round>
+                                        <sub>
+                                            <var>bmlp</var>
+                                            <div>
+                                                <num>1000</num><num>2</num>
+                                            </div>
+                                        </sub>
+                                        <num>-3</num>
+                                    </round>
+                                    <round>
+                                        <sub>
+                                            <var>bmlp</var>
+                                            <div>
+                                                <num>1000000</num><num>2</num>
+                                            </div>
+                                        </sub>
+                                        <num>-6</num>
+                                    </round>
+                            </sub>
+                            <num>1000</num>
+                        </div>
+                        <num>0</num>
+                    </round>
+                    <str>,</str>
+                </concat>
+            </if>
+            <if>
+                <greater>
+                    <round>
+                        <sub>
+                            <var>bmlp</var>
+                            <div>
+                                <num>1000</num><num>2</num>
+                            </div>
+                        </sub>
+                        <num>-3</num>
+                    </round>
+                    <num>0</num>
+                </greater>
+                <if>
+                    <equal>
+                        <div>
+                            <round>
+                                <sub>
+                                    <div>
+                                        <sub>
+                                                <var>bmlp</var>
+                                                <round>
+                                                    <sub>
+                                                        <var>bmlp</var>
+                                                        <div>
+                                                            <num>1000</num><num>2</num>
+                                                        </div>
+                                                    </sub>
+                                                    <num>-3</num>
+                                                </round>
+                                        </sub>
+                                        <num>1</num>
+                                    </div>
+                                    <num>50</num>
+                                </sub>
+                                <num>-2</num>
+                            </round>
+                            <num>100</num>
+                        </div>
+                        <num>0</num>
+                    </equal>
+                    <concat>
+                        <str>0</str>
+                        <if>
+                            <equal>
+                                <div>
+                                    <round>
+                                        <sub>
+                                            <div>
+                                                <sub>
+                                                        <var>bmlp</var>
+                                                        <round>
+                                                            <sub>
+                                                                <var>bmlp</var>
+                                                                <div>
+                                                                    <num>1000</num><num>2</num>
+                                                                </div>
+                                                            </sub>
+                                                            <num>-3</num>
+                                                        </round>
+                                                </sub>
+                                                <num>1</num>
+                                            </div>
+                                            <num>5</num>
+                                        </sub>
+                                        <num>-1</num>
+                                    </round>
+                                    <num>10</num>
+                                </div>
+                                <num>0</num>
+                            </equal>
+                            <str>0</str>
+                        </if>
+                    </concat>
+                </if>
+            </if>
+            <concat>
+                <round>
+                    <div>
+                        <sub>
+                                <round>
+                                    <sub>
+                                        <var>bmlp</var>
+                                        <div>
+                                            <num>1</num><num>2</num>
+                                        </div>
+                                    </sub>
+                                    <num>0</num>
+                                </round>
+                                <round>
+                                    <sub>
+                                        <var>bmlp</var>
+                                        <div>
+                                            <num>1000</num><num>2</num>
+                                        </div>
+                                    </sub>
+                                    <num>-3</num>
+                                </round>
+                        </sub>
+                        <num>1</num>
+                    </div>
+                    <num>0</num>
+                </round>
+                <str></str>
+            </concat>
+            <str>$f</str>
         </line>
+
         <line>
             <str>{black}</str>
         </line>


### PR DESCRIPTION
显示血魔法宝珠等级；
修正血魔法数据显示（0,0,0->0)；
对齐冒号（更整齐）；
调整了实体的行位置，与世界接近（二字相邻、四字相邻更整齐）
效果如图：
![image](https://github.com/user-attachments/assets/3617908c-5d43-4cfe-9e36-8bfa67dbe610)
旧版本如图：
![image](https://github.com/user-attachments/assets/6afe11da-50d5-4a09-ae5c-cc7284c9c51f)

尤其是对于刚进入地图的玩家：
新：
![image](https://github.com/user-attachments/assets/4def6394-5bfd-4192-843c-48d016e872e8)

旧：
![image](https://github.com/user-attachments/assets/8e192468-6f33-4ba7-9793-a5788b41b796)
