### PR TITLE
refactor: migrate release workflow to Deno

### DIFF
--- a/.github/scripts/release.ts
+++ b/.github/scripts/release.ts
@@ -1,0 +1,84 @@
+import { copy, ensureDir } from 'jsr:@std/fs@1.0.20'
+import { basename, dirname, join, resolve } from 'jsr:@std/path@1.1.3'
+import { join as posixJoin } from 'jsr:@std/path@1.1.3/posix'
+
+import _SevenZip, { type SevenZipModuleFactory } from 'npm:7z-wasm@1.2.0'
+import { consola } from 'npm:consola@3.4.2'
+import download from 'npm:download@8.0.0'
+
+const SevenZip = _SevenZip as unknown as SevenZipModuleFactory
+
+const refName = Deno.env.get('REF_NAME')!
+const repoPath = Deno.env.get('REPO_PATH')!
+const assetsPath = Deno.env.get('ASSETS_PATH')!
+
+// === 配置 ===
+const pathsToBePacked = [
+  'config',
+  'resources',
+  'GregTech.lang',
+  'GregTech_US.lang',
+  'GTNH介绍.txt',
+  'README.md',
+]
+
+const toBeRenamed: Record<string, string> = {
+  'README.md': '看我.md',
+  'resources': 'config/txloader/forceload',
+  'GregTech.lang': 'GregTech_zh_CN.lang',
+}
+
+const absoluteRepoPath = resolve(repoPath)
+const absoluteTempPath = await Deno.makeTempDir({ prefix: 'gtnh-release-' })
+const absoluteAssetsPath = resolve(assetsPath)
+
+// === 创建目录 ===
+consola.start('正在创建目录...')
+await ensureDir(absoluteAssetsPath)
+
+// === 打包文件 ===
+consola.start('正在打包文件...')
+for (const p of pathsToBePacked) {
+  const srcPath = join(absoluteRepoPath, p)
+  const destPath = join(absoluteTempPath, toBeRenamed[p] ?? p)
+  await ensureDir(dirname(destPath))
+  await copy(srcPath, destPath, { overwrite: true })
+  consola.info(`  复制: ${p} -> ${toBeRenamed[p] ?? p}`)
+}
+
+// === 创建 7z 压缩包 ===
+consola.start('正在创建 7z 压缩包...')
+
+const archiveName = `${refName}.7z`
+
+const sevenZip = await SevenZip()
+sevenZip.FS.mkdir('/src')
+sevenZip.FS.mkdir('/dest')
+sevenZip.FS.mount(sevenZip.NODEFS, { root: absoluteTempPath }, '/src')
+sevenZip.FS.mount(
+  sevenZip.NODEFS,
+  { root: absoluteAssetsPath },
+  '/dest',
+)
+sevenZip.FS.chdir('/src')
+const outputInVfs = posixJoin('/dest', archiveName)
+const result = sevenZip.callMain([
+  'a',
+  '-t7z',
+  '-mx=9',
+  outputInVfs,
+  '*',
+]) as unknown as number
+
+if (result !== 0) {
+  throw new Error(`7z 压缩失败，返回码: ${result}`)
+}
+
+// === 下载 NotEnoughCharacters ===
+consola.start('正在下载 NotEnoughCharacters...')
+const necUrl =
+  'https://raw.githubusercontent.com/Kiwi233/Translation-of-GTNH/NotEnoughCharacters/NotEnoughCharacters-1.6.1.jar'
+await download(necUrl, absoluteAssetsPath)
+consola.success(`下载完成: ${join(absoluteAssetsPath, basename(necUrl))}`)
+
+consola.success('构建完成!')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,32 +5,29 @@ on:
     tags:
       - '*'
 
+env:
+  REPO_PATH: .repo
+  ASSETS_PATH: .assets
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
-          path: repo
-      - uses: actions/setup-python@v3
+          path: ${{ env.REPO_PATH }}
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
         with:
-          python-version: '3.10'
-      - name: Ensure temp dir
-        run: mkdir -p temp
-      - name: Ensure assets dir
-        run: mkdir -p assets
-      - name: Pack
-        run: python repo/.github/scripts/pack.py
-      - name: Zip
-        uses: edgarrc/action-7z@v1
-        with:
-          args: 7z a -t7z -mx=9 ./assets/${{ github.ref_name }}.7z ./temp/*
-      - name: Add NotEnoughCharacters
-        uses: wei/wget@v1
-        with:
-          args: -O assets/NotEnoughCharacters-1.6.1.jar https://github.com/Kiwi233/Translation-of-GTNH/raw/NotEnoughCharacters/NotEnoughCharacters-1.6.1.jar
+          deno-version: "^2"
+          cache: true
+          cache-hash: "release"
+      - name: Build Release Assets
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: deno run -A ${{ env.REPO_PATH }}/.github/scripts/release.ts
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
@@ -38,5 +35,5 @@ jobs:
           body: |
             请阅读主页ReadMe以获知详细用法
           files: |
-            ./assets/${{ github.ref_name }}.7z
-            ./assets/NotEnoughCharacters-1.6.1.jar
+            ${{ env.ASSETS_PATH }}/${{ github.ref_name }}.7z
+            ${{ env.ASSETS_PATH }}/NotEnoughCharacters-1.6.1.jar


### PR DESCRIPTION
- Replace Python pack.py with Deno release.ts
- Use 7z-wasm for compression instead of external 7z action
- Use download package for fetching NotEnoughCharacters.jar
- Add environment variables for REPO_PATH and ASSETS_PATH