### PR TITLE
refactor: migrate from Deno to Bun for workflows and scripts

### DIFF
--- a/.github/scripts/cleanup-nightly-builds.ts
+++ b/.github/scripts/cleanup-nightly-builds.ts
@@ -1,13 +1,13 @@
-import { $ } from 'npm:zx@8.3.2'
-import { consola } from 'npm:consola@3.4.2'
+import { $ } from 'zx@8.3.2'
+import { consola } from 'consola@3.4.2'
 
-const repo = Deno.env.get('GITHUB_REPOSITORY') || (() => {
+const repo = Bun.env.GITHUB_REPOSITORY || (() => {
   consola.error('GITHUB_REPOSITORY is not set')
-  Deno.exit(1)
+  process.exit(1)
 })()
-const currentTag = Deno.env.get('NB_TAG') || (() => {
+const currentTag = Bun.env.NB_TAG || (() => {
   consola.error('NB_TAG is not set')
-  Deno.exit(1)
+  process.exit(1)
 })()
 
 consola.start('正在获取 release 列表...')

--- a/.github/scripts/setup-nightly-build-datetime-envs.ts
+++ b/.github/scripts/setup-nightly-build-datetime-envs.ts
@@ -1,7 +1,7 @@
-import * as core from 'npm:@actions/core@1.11.1'
-import dayjs from 'npm:dayjs@1.11.13'
-import utc from 'npm:dayjs@1.11.13/plugin/utc.js'
-import timezone from 'npm:dayjs@1.11.13/plugin/timezone.js'
+import * as core from '@actions/core@1.11.1'
+import dayjs from 'dayjs@1.11.13'
+import utc from 'dayjs@1.11.13/plugin/utc.js'
+import timezone from 'dayjs@1.11.13/plugin/timezone.js'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -7,12 +7,18 @@ on:
     - cron: '0 18 * * *'
 
 env:
+  BUN_VERSION: 1.3.5
+  BUN_INSTALL_CACHE_DIR: .bun-install-cache.local
+
   PARATRANZ_TOKEN: ${{ secrets.PARATRANZ_TOKEN }}
   PARATRANZ_PROJECT_ID: ${{ secrets.PARATRANZ_PROJECT_ID }}
+
   GIT_AUTHOR: MuXiu1997 <muxiu1997@muxiu1997.com>
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   REPO_PATH: .repo
   ASSETS_PATH: .assets
+  PARATRANZ_CACHE_DIR: .paratranz-cache
 
 jobs:
   nightly-build:
@@ -30,15 +36,19 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: ${{ env.REPO_PATH }}
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          deno-version: '^2'
-          cache: true
-          cache-hash: 'nightly-build'
+          bun-version: 1.3.5
+      - name: Setup Bun Global Module Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.BUN_INSTALL_CACHE_DIR }}
+          key: bun-install-cache--${{ github.job }}
 
       - name: Setup Datetime Related Envs
-        run: deno run -A ${{ env.REPO_PATH }}/.github/scripts/setup-nightly-build-datetime-envs.ts
+        run: bun run ${{ env.REPO_PATH }}/.github/scripts/setup-nightly-build-datetime-envs.ts
 
       - name: ParaTranz To Quest Book
         run: >-
@@ -57,7 +67,7 @@ jobs:
         env:
           IS_NIGHTLY_BUILD: 'true'
           ARCHIVE_NAME: nightly-${{ env.NB_LOCAL_DATE }}.7z
-        run: deno run -A ${{ env.REPO_PATH }}/.github/scripts/release.ts
+        run: bun run ${{ env.REPO_PATH }}/.github/scripts/release.ts
 
       - name: Push tag
         working-directory: ${{ env.REPO_PATH }}
@@ -89,15 +99,19 @@ jobs:
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github/scripts
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          deno-version: '^2'
-          cache: true
-          cache-hash: 'cleanup-nightly'
+          bun-version: 1.3.5
+      - name: Setup Bun Global Module Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.BUN_INSTALL_CACHE_DIR }}
+          key: bun-install-cache--${{ github.job }}
 
       - name: Setup Datetime Related Envs
-        run: deno run -A .github/scripts/setup-nightly-build-datetime-envs.ts
+        run: bun run .github/scripts/setup-nightly-build-datetime-envs.ts
 
       - name: Cleanup Outdated Nightly Builds
-        run: deno run -A .github/scripts/cleanup-nightly-builds.ts
+        run: bun run .github/scripts/cleanup-nightly-builds.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - '*'
 
 env:
+  BUN_VERSION: 1.3.5
+  BUN_INSTALL_CACHE_DIR: .bun-install-cache.local
+
   REPO_PATH: .repo
   ASSETS_PATH: .assets
 
@@ -18,12 +21,17 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: ${{ env.REPO_PATH }}
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          deno-version: '^2'
-          cache: true
-          cache-hash: 'release'
+          bun-version: 1.3.5
+      - name: Setup Bun Global Module Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.BUN_INSTALL_CACHE_DIR }}
+          key: bun-install-cache--${{ github.job }}
+
       - name: Build Release Assets
         env:
           ARCHIVE_NAME: ${{ github.ref_name }}.7z


### PR DESCRIPTION
- Remove 'npm:' prefixes from imports
- Replace Deno setup with Bun in workflows and enable caching