### PR TITLE
refactor: migrate nightly build workflow from Python to Bun

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   BUN_VERSION: 1.3.5
-  BUN_INSTALL_CACHE_DIR: .bun-install-cache.local
+  BUN_INSTALL_CACHE_DIR: .bun-install-cache.local.d
 
   PARATRANZ_TOKEN: ${{ secrets.PARATRANZ_TOKEN }}
   PARATRANZ_PROJECT_ID: ${{ secrets.PARATRANZ_PROJECT_ID }}
@@ -16,9 +16,9 @@ env:
   GIT_AUTHOR: MuXiu1997 <muxiu1997@muxiu1997.com>
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  REPO_PATH: .repo
-  ASSETS_PATH: .assets
-  PARATRANZ_CACHE_DIR: .paratranz-cache
+  REPO_PATH: .repo.local.d
+  ASSETS_PATH: .assets.local.d
+  PARATRANZ_CACHE_DIR: .paratranz-cache.local.d
 
 jobs:
   nightly-build:
@@ -29,9 +29,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: MuXiu1997/GTNH-translation-compare
-          ref: main
-      - name: Ensure Dependencies
-        uses: ./.github/actions/ensure-dependencies
+          ref: next
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -50,17 +48,24 @@ jobs:
       - name: Setup Datetime Related Envs
         run: bun run ${{ env.REPO_PATH }}/.github/scripts/setup-nightly-build-datetime-envs.ts
 
+      - name: Cache ParaTranz Files
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PARATRANZ_CACHE_DIR }}
+          key: paratranz-cache-${{ github.run_id }}
+          restore-keys: |
+            paratranz-cache-
       - name: ParaTranz To Quest Book
         run: >-
-          poetry run python main.py action paratranz-to-quest-book
+          bun run index.ts from-paratranz:quest-book
           --repo-path='${{ env.REPO_PATH }}'
       - name: ParaTranz To Lang And zs
         run: >-
-          poetry run python main.py action paratranz-to-lang-and-zs
+          bun run index.ts from-paratranz:lang-zs
           --repo-path='${{ env.REPO_PATH }}'
       - name: ParaTranz To GT Lang
         run: >-
-          poetry run python main.py action paratranz-to-gt-lang
+          bun run index.ts from-paratranz:gt-lang
           --repo-path='${{ env.REPO_PATH }}'
 
       - name: Build Nightly Assets


### PR DESCRIPTION
- Update cache directory names with .local.d suffix
- Switch checkout ref from main to next branch
- Remove Ensure Dependencies step
- Add ParaTranz files caching
- Replace Python/poetry commands with Bun TypeScript scripts