### PR TITLE
feat: pass extra lang files to to-paratranz:lang-zs

### DIFF
--- a/.github/workflows/3-lang-and-zs-to-paratranz.yml
+++ b/.github/workflows/3-lang-and-zs-to-paratranz.yml
@@ -67,6 +67,8 @@ jobs:
         run: >-
           bun run src/index.ts to-paratranz:lang-zs
           --modpack-path='${{ env.MODPACK_PATH }}'
+          --extra-lang="config/amazingtrophies/lang/en_US.lang"
+          --extra-lang="config/txloader/**/en_US.lang"
 
       - name: Close Issue
         uses: peter-evans/close-issue@v2.0.0


### PR DESCRIPTION
## 背景

GTNH 整合包里有部分 lang 文件并不打包在 mod jar 内，而是直接放在 `config/<mod>/lang/` 下，比如：

- `config/amazingtrophies/lang/en_US.lang`
- `config/txloader/**/en_US.lang`（按区域分多份）

`to-paratranz:lang-zs` 默认只扫 `mods/**/*.jar` 里的 lang 资源，因此这些"jar 外 lang"会漏掉。

## 改动

在 `3-lang-and-zs-to-paratranz.yml` 的 `Run Script` 步骤上加两个 `--extra-lang` 参数，把它们也喂给同步命令：

```diff
        run: >-
          bun run src/index.ts to-paratranz:lang-zs
          --modpack-path='\${{ env.MODPACK_PATH }}'
+         --extra-lang="config/amazingtrophies/lang/en_US.lang"
+         --extra-lang="config/txloader/**/en_US.lang"
```

仅 1 个文件、+2 行、零删除。

## 依赖

依赖 [MuXiu1997/GTNH-translation-compare#9](https://github.com/MuXiu1997/GTNH-translation-compare/pull/9) `feat: add --extra-lang to upload lang files outside mod jars`，给 `to-paratranz:lang-zs` 命令加 `--extra-lang` flag。

✅ 该 PR **已 merged 到 `next` 分支**，而 `setup-compare-repo` action 默认正是从 `MuXiu1997/GTNH-translation-compare@next` 拉取 compare 工具，因此前置依赖已满足，本 PR 合入后即可生效。

## 与其它 PR 的关系

- 该 commit 原本是 #746 中的第二个 commit (`e5e9acb`)，由 @Discreater 编写。这里通过 cherry-pick 单独抽出，作者保留为 @Discreater。
- 与 #747 (`feat: support downloading modpack from GitHub Actions artifact`) 互相独立，改动 workflow 文件的不同段落（`Run Script` vs `Ensure Modpack`），合入顺序无关，无冲突。

## 验证

- 在 fork 上之前的端到端测试已确认 `config/amazingtrophies/lang/*.lang` 等文件确实存在于解压后的 `MODPACK_PATH` 下（参见 #747 的 inspect 日志）
- compare 工具的 `--extra-lang` flag 通过 glob 在 `MODPACK_PATH` 内扫描，行为已在 MuXiu1997/GTNH-translation-compare#9 验证